### PR TITLE
Generic extension exception and multiple extension methos for single userdata: fixes

### DIFF
--- a/src/MoonSharp.Interpreter/Interop/BasicDescriptors/DispatchingUserDataDescriptor.cs
+++ b/src/MoonSharp.Interpreter/Interop/BasicDescriptors/DispatchingUserDataDescriptor.cs
@@ -13,7 +13,6 @@ namespace MoonSharp.Interpreter.Interop.BasicDescriptors
 	/// </summary>
 	public abstract class DispatchingUserDataDescriptor : IUserDataDescriptor, IOptimizableDescriptor
 	{
-		private int m_ExtMethodsVersion = 0;
 		private Dictionary<string, IMemberDescriptor> m_MetaMembers = new Dictionary<string, IMemberDescriptor>();
 		private Dictionary<string, IMemberDescriptor> m_Members = new Dictionary<string, IMemberDescriptor>();
 
@@ -236,10 +235,8 @@ namespace MoonSharp.Interpreter.Interop.BasicDescriptors
 			if (v == null) v = TryIndex(script, obj, Camelify(index.String));
 			if (v == null) v = TryIndex(script, obj, UpperFirstLetter(Camelify(index.String)));
 
-			if (v == null && m_ExtMethodsVersion < UserData.GetExtensionMethodsChangeVersion())
+			if (v == null)
 			{
-				m_ExtMethodsVersion = UserData.GetExtensionMethodsChangeVersion();
-
 				v = TryIndexOnExtMethod(script, obj, index.String);
 				if (v == null) v = TryIndexOnExtMethod(script, obj, UpperFirstLetter(index.String));
 				if (v == null) v = TryIndexOnExtMethod(script, obj, Camelify(index.String));

--- a/src/MoonSharp.Interpreter/Interop/UserDataRegistries/ExtensionMethodsRegistry.cs
+++ b/src/MoonSharp.Interpreter/Interop/UserDataRegistries/ExtensionMethodsRegistry.cs
@@ -153,17 +153,25 @@ namespace MoonSharp.Interpreter.Interop.UserDataRegistries
 
 		private static Type GetGenericMatch(Type extensionType, Type extendedType)
 		{
-			extensionType = extensionType.GetGenericTypeDefinition();
+            if (!extensionType.IsGenericParameter)
+            {
+                extensionType = extensionType.GetGenericTypeDefinition();
 
-			foreach (Type t in extendedType.GetAllImplementedTypes())
-			{
-				if (t.IsGenericType && t.GetGenericTypeDefinition() == extensionType)
-				{
-					return t;
-				}
-			}
+                foreach (Type t in extendedType.GetAllImplementedTypes())
+                {
+                    if (t.IsGenericType && t.GetGenericTypeDefinition() == extensionType)
+                    {
+                        return t;
+                    }
+                }
+            }
 
-			return null;
+            /*if (extendedType.IsGenericParameter)
+            {
+                return extendedType;
+            }*/
+
+            return null;
 		}
 
 	}


### PR DESCRIPTION
## Attribution
This PR is from @havietisov - originally submitted as
https://github.com/moonsharp-devs/moonsharp/pull/130

---

In case we called some extension method in context of some userdata, we are not allowed to call
any other because they will not be indexed (always nil)

example :
userdata.ExtMethod1() --called fine
userdata.ExtMethod2() --null indexer!

and, if we call ExtMethod2 first, ExtMethod1 will be nil

ExtensionMethodsRegistry.GetGenericMatch trying to create GetGenericTypeDefinition of type
parameter.
Example:
TweenSettingsExtensions.SetEase<T>(this T t, Ease ease) //causes exception being thrown, because
we are not allowed to create T<>