### PR TITLE
Integrate upstream PR #130: Fix extension method bugs

### DIFF
--- a/src/MoonSharp.Interpreter/Interop/BasicDescriptors/DispatchingUserDataDescriptor.cs
+++ b/src/MoonSharp.Interpreter/Interop/BasicDescriptors/DispatchingUserDataDescriptor.cs
@@ -13,7 +13,6 @@ namespace MoonSharp.Interpreter.Interop.BasicDescriptors
 	/// </summary>
 	public abstract class DispatchingUserDataDescriptor : IUserDataDescriptor, IOptimizableDescriptor
 	{
-		private int m_ExtMethodsVersion = 0;
 		private Dictionary<string, IMemberDescriptor> m_MetaMembers = new Dictionary<string, IMemberDescriptor>();
 		private Dictionary<string, IMemberDescriptor> m_Members = new Dictionary<string, IMemberDescriptor>();
 
@@ -236,10 +235,8 @@ namespace MoonSharp.Interpreter.Interop.BasicDescriptors
 			if (v == null) v = TryIndex(script, obj, Camelify(index.String));
 			if (v == null) v = TryIndex(script, obj, UpperFirstLetter(Camelify(index.String)));
 
-			if (v == null && m_ExtMethodsVersion < UserData.GetExtensionMethodsChangeVersion())
+			if (v == null)
 			{
-				m_ExtMethodsVersion = UserData.GetExtensionMethodsChangeVersion();
-
 				v = TryIndexOnExtMethod(script, obj, index.String);
 				if (v == null) v = TryIndexOnExtMethod(script, obj, UpperFirstLetter(index.String));
 				if (v == null) v = TryIndexOnExtMethod(script, obj, Camelify(index.String));

--- a/src/MoonSharp.Interpreter/Interop/UserDataRegistries/ExtensionMethodsRegistry.cs
+++ b/src/MoonSharp.Interpreter/Interop/UserDataRegistries/ExtensionMethodsRegistry.cs
@@ -153,17 +153,25 @@ namespace MoonSharp.Interpreter.Interop.UserDataRegistries
 
 		private static Type GetGenericMatch(Type extensionType, Type extendedType)
 		{
-			extensionType = extensionType.GetGenericTypeDefinition();
+            if (!extensionType.IsGenericParameter)
+            {
+                extensionType = extensionType.GetGenericTypeDefinition();
 
-			foreach (Type t in extendedType.GetAllImplementedTypes())
-			{
-				if (t.IsGenericType && t.GetGenericTypeDefinition() == extensionType)
-				{
-					return t;
-				}
-			}
+                foreach (Type t in extendedType.GetAllImplementedTypes())
+                {
+                    if (t.IsGenericType && t.GetGenericTypeDefinition() == extensionType)
+                    {
+                        return t;
+                    }
+                }
+            }
 
-			return null;
+            /*if (extendedType.IsGenericParameter)
+            {
+                return extendedType;
+            }*/
+
+            return null;
 		}
 
 	}


### PR DESCRIPTION
This PR integrates the fixes from upstream PR https://github.com/moonsharp-devs/moonsharp/pull/130 by @havietisov.

## Fixes

1. **Multiple extension methods on same userdata** - Removed the version check that prevented calling multiple extension methods on the same userdata instance
2. **Generic extension methods exception** - Added check to prevent calling `GetGenericTypeDefinition()` on generic parameters

## Changes

- Removed version check in `DispatchingUserDataDescriptor.cs` that was preventing multiple extension method calls
- Added `\!extensionType.IsGenericParameter` check in `ExtensionMethodsRegistry.cs` to fix exceptions with generic extension methods

Original PR has been open since 2016 and addresses legitimate bugs that affect Unity developers using libraries like DOTween.